### PR TITLE
fix: 날짜 계산 오류

### DIFF
--- a/src/main/java/bokjak/bokjakserver/common/constant/GlobalConstants.java
+++ b/src/main/java/bokjak/bokjakserver/common/constant/GlobalConstants.java
@@ -10,7 +10,6 @@ public class GlobalConstants {
     /**
      * Category
      */
-    public static final int WEEK_SIZE = 7;
 
     /**
      * Location

--- a/src/main/java/bokjak/bokjakserver/common/constant/GlobalConstants.java
+++ b/src/main/java/bokjak/bokjakserver/common/constant/GlobalConstants.java
@@ -6,11 +6,6 @@ public class GlobalConstants {
      */
     public static final String[] APPOINTED_URIS = {"/auth/login/admin", "/auth/reissue", "/auth/login", "/auth/signup", "/users/check/nickname/**", "/hello/**", "/categories/**", "/files"};
 
-
-    /**
-     * Category
-     */
-
     /**
      * Location
      */

--- a/src/main/java/bokjak/bokjakserver/domain/category/dto/CongestionHistoricalDateChoice.java
+++ b/src/main/java/bokjak/bokjakserver/domain/category/dto/CongestionHistoricalDateChoice.java
@@ -3,6 +3,7 @@ package bokjak.bokjakserver.domain.category.dto;
 import bokjak.bokjakserver.common.constant.GlobalConstants;
 import bokjak.bokjakserver.common.exception.StatusCode;
 import bokjak.bokjakserver.domain.category.exception.CategoryException;
+import bokjak.bokjakserver.util.CustomDateUtils;
 import bokjak.bokjakserver.util.enums.EnumModel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -34,19 +35,13 @@ public enum CongestionHistoricalDateChoice implements EnumModel<String> {
 
     // toDateTime: congestionDateFilter에 대해 요청된 요일(name 필드)에 따라 값을 다르게 변환. SQL 날짜 형식에 맞도록 포맷
     public static String toDateTime(CongestionHistoricalDateChoice choice) {
-        Calendar calendar = Calendar.getInstance();
-        // 한 주의 시작 요일 설정: 복쟉복쟉의 일주일 시작 요일은 월요일, 반면 Calendar의 디폴트 시작 요일은 일요일
-        calendar.setFirstDayOfWeek(Calendar.MONDAY);
-        // 일주일 전으로 설정: 과거 일주일간의 혼잡도 데이터를 보기 위함
-        calendar.add(Calendar.DATE, -GlobalConstants.WEEK_SIZE);
-        // 요일에 따라 날짜 설정
-        calendar.set(Calendar.DAY_OF_WEEK, switchChoiceToCalendarDayOfWeek(choice));
+        Calendar calendar = CustomDateUtils.makePastWeekDayDate(switchChoiceToDayOfWeek(choice));
 
         SimpleDateFormat formatter = new SimpleDateFormat(GlobalConstants.DATE_FORMAT);
         return formatter.format(calendar.getTime());
     }
 
-    private static int switchChoiceToCalendarDayOfWeek(CongestionHistoricalDateChoice choice) {// choice에 따라 다른 요일값으로 설정
+    private static int switchChoiceToDayOfWeek(CongestionHistoricalDateChoice choice) {// choice에 따라 다른 요일값으로 설정
         return switch (choice) {
             case MON -> Calendar.MONDAY;
             case TUE -> Calendar.TUESDAY;

--- a/src/main/java/bokjak/bokjakserver/domain/category/dto/CongestionHistoricalDateChoice.java
+++ b/src/main/java/bokjak/bokjakserver/domain/category/dto/CongestionHistoricalDateChoice.java
@@ -35,24 +35,28 @@ public enum CongestionHistoricalDateChoice implements EnumModel<String> {
     // toDateTime: congestionDateFilter에 대해 요청된 요일(name 필드)에 따라 값을 다르게 변환. SQL 날짜 형식에 맞도록 포맷
     public static String toDateTime(CongestionHistoricalDateChoice choice) {
         Calendar calendar = Calendar.getInstance();
-        if (choice != SUN) calendar.add(Calendar.DATE, -GlobalConstants.WEEK_SIZE);// 일주일 전
-
-        switch (choice) {
-            case MON -> calendar.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY);
-            case TUE -> calendar.set(Calendar.DAY_OF_WEEK, Calendar.TUESDAY);
-            case WED -> calendar.set(Calendar.DAY_OF_WEEK, Calendar.WEDNESDAY);
-            case THU -> calendar.set(Calendar.DAY_OF_WEEK, Calendar.THURSDAY);
-            case FRI -> calendar.set(Calendar.DAY_OF_WEEK, Calendar.FRIDAY);
-            case SAT -> calendar.set(Calendar.DAY_OF_WEEK, Calendar.SATURDAY);
-            case SUN -> calendar.set(Calendar.DAY_OF_WEEK, Calendar.SUNDAY);
-
-            default -> throw new IllegalArgumentException(StatusCode.INTERNAL_SERVER_ERROR.getMessage());  // Internal Error 이여야 함
-        }
+        // 한 주의 시작 요일 설정: 복쟉복쟉의 일주일 시작 요일은 월요일, 반면 Calendar의 디폴트 시작 요일은 일요일
+        calendar.setFirstDayOfWeek(Calendar.MONDAY);
+        // 일주일 전으로 설정: 과거 일주일간의 혼잡도 데이터를 보기 위함
+        calendar.add(Calendar.DATE, -GlobalConstants.WEEK_SIZE);
+        // 요일에 따라 날짜 설정
+        calendar.set(Calendar.DAY_OF_WEEK, switchChoiceToCalendarDayOfWeek(choice));
 
         SimpleDateFormat formatter = new SimpleDateFormat(GlobalConstants.DATE_FORMAT);
         return formatter.format(calendar.getTime());
     }
 
+    private static int switchChoiceToCalendarDayOfWeek(CongestionHistoricalDateChoice choice) {// choice에 따라 다른 요일값으로 설정
+        return switch (choice) {
+            case MON -> Calendar.MONDAY;
+            case TUE -> Calendar.TUESDAY;
+            case WED -> Calendar.WEDNESDAY;
+            case THU -> Calendar.THURSDAY;
+            case FRI -> Calendar.FRIDAY;
+            case SAT -> Calendar.SATURDAY;
+            case SUN -> Calendar.SUNDAY;
+        };
+    }
     @Override
     public String getKey() {
         return name();

--- a/src/main/java/bokjak/bokjakserver/domain/location/service/LocationService.java
+++ b/src/main/java/bokjak/bokjakserver/domain/location/service/LocationService.java
@@ -79,9 +79,6 @@ public class LocationService {
         LocalDateTime start = CustomDateUtils.makePastWeekDayDateTime(Calendar.MONDAY, LocalTime.MIN);// 월요일 00시 00
         LocalDateTime end = CustomDateUtils.makePastWeekDayDateTime(Calendar.SUNDAY, LocalTime.MAX);  // 일요일 24시 59
 
-        System.out.println("start = " + start);
-        System.out.println("end = " + end);
-
         Page<Location> resultPage = locationRepository.getTopOfWeeklyAverageCongestion(pageable, start, end);
 
         return makeLocationCardPageResponse(currentUser, resultPage);

--- a/src/main/java/bokjak/bokjakserver/domain/location/service/LocationService.java
+++ b/src/main/java/bokjak/bokjakserver/domain/location/service/LocationService.java
@@ -21,6 +21,7 @@ import bokjak.bokjakserver.domain.location.model.Location;
 import bokjak.bokjakserver.domain.location.repository.LocationRepository;
 import bokjak.bokjakserver.domain.user.model.User;
 import bokjak.bokjakserver.domain.user.service.UserService;
+import bokjak.bokjakserver.util.CustomDateUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -75,13 +76,11 @@ public class LocationService {
     public PageResponse<LocationCardResponse> getTopRelaxingLocations(Pageable pageable) {
         User currentUser = userService.getCurrentUser();
 
-        Calendar startDate = Calendar.getInstance(), endDate = Calendar.getInstance();
-        startDate.add(Calendar.DATE, -GlobalConstants.WEEK_SIZE);
-        startDate.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY);
-        endDate.set(Calendar.DAY_OF_WEEK, Calendar.SUNDAY);// Calendar의 주 시작 기준은 일~월, 복쟉복쟉은 월~일
+        LocalDateTime start = CustomDateUtils.makePastWeekDayDateTime(Calendar.MONDAY, LocalTime.MIN);// 월요일 00시 00
+        LocalDateTime end = CustomDateUtils.makePastWeekDayDateTime(Calendar.SUNDAY, LocalTime.MAX);  // 일요일 24시 59
 
-        LocalDateTime start = makeZonedDateTime(startDate, LocalTime.MIN);  // 월요일 00시 00
-        LocalDateTime end = makeZonedDateTime(endDate, LocalTime.MAX);      // 일요일 24시 59
+        System.out.println("start = " + start);
+        System.out.println("end = " + end);
 
         Page<Location> resultPage = locationRepository.getTopOfWeeklyAverageCongestion(pageable, start, end);
 
@@ -158,14 +157,6 @@ public class LocationService {
     }
 
     /* private 함수 */
-
-    private LocalDateTime makeZonedDateTime(Calendar calendar, LocalTime localTime) {
-        return ZonedDateTime.of(
-                LocalDate.ofInstant(calendar.toInstant(), calendar.getTimeZone().toZoneId()),
-                localTime,
-                ZoneId.systemDefault()
-        ).toLocalDateTime();
-    }
 
     private PageResponse<LocationCardResponse> makeLocationCardPageResponse(User currentUser, Page<Location> resultPage) {
         List<Long> bookmarkedLocationIdList = locationBookmarkRepository.findAllByUser(currentUser).stream()

--- a/src/main/java/bokjak/bokjakserver/util/CustomDateUtils.java
+++ b/src/main/java/bokjak/bokjakserver/util/CustomDateUtils.java
@@ -1,0 +1,32 @@
+package bokjak.bokjakserver.util;
+
+import java.time.*;
+import java.util.Calendar;
+
+public class CustomDateUtils {
+
+    public static LocalDateTime makePastWeekDayDateTime(int dayOfWeek, LocalTime localTime) {
+        return toSpecificLocalTime(makePastWeekDayDate(dayOfWeek), localTime);
+    }
+
+    public static Calendar makePastWeekDayDate(int dayOfWeek) {
+        Calendar calendar = Calendar.getInstance();
+        // 한 주의 시작 요일 설정: 복쟉복쟉의 일주일 시작 요일은 월요일, 반면 Calendar의 디폴트 시작 요일은 일요일
+        calendar.setFirstDayOfWeek(Calendar.MONDAY);
+        // 일주일 전으로 설정: 과거 일주일간의 혼잡도 데이터를 보기 위함
+        calendar.add(Calendar.DATE, -Calendar.DAY_OF_WEEK);
+        // 요일에 따라 날짜 설정
+        calendar.set(Calendar.DAY_OF_WEEK, dayOfWeek);
+        return calendar;
+    }
+
+
+
+    private static LocalDateTime toSpecificLocalTime(Calendar calendar, LocalTime localTime) {
+        return ZonedDateTime.of(
+                LocalDate.ofInstant(calendar.toInstant(), calendar.getTimeZone().toZoneId()),
+                localTime,
+                ZoneId.systemDefault()
+        ).toLocalDateTime();
+    }
+}


### PR DESCRIPTION
## PR 요약
카테고리 조회, 로케이션 TOP 리스트 조회에서 요일별 저번주 날짜 계산 오류 해결

## 구현한 내용 또는 수정한 내용
![image](https://github.com/Akatsuki-USW/Buzzzzing-Server/assets/72124326/8a1dceb8-2e11-46d0-ba85-958118a12561)

요청한 날짜 : 0723 (일요일)
문제인 부분 : 이번주의 날짜가 나오고 있음. 저번주인 0710 ~ 0716의 데이터가 응답돼야 함
문제 원인 : Java Calendar의 디폴트 시작 요일이 일요일이었음.

해결 : -> 월요일로 변경 

## 추가로 알리고 싶은 내용

## 관련 이슈

## 체크리스트

- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  WBS 업데이트해주세요. (제목에 WBS 번호 달아주세요)
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요!
