### PR TITLE
feat: 잘못된 url exception

### DIFF
--- a/src/main/java/bokjak/bokjakserver/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/bokjak/bokjakserver/common/exception/GlobalExceptionHandler.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.io.IOException;
 
@@ -122,6 +123,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponse.error(StatusCode.INTERNAL_SERVER_ERROR.getStatusCode(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ApiResponse<?> handleNotFoundUrl(final NoHandlerFoundException ex) {
+        log.error("not found url request {} - {}", ex.getClass().getSimpleName(), ex.getMessage());
+        return error(NOT_FOUND_URL.getStatusCode(), NOT_FOUND_URL.getMessage());
+
     }
 }
 

--- a/src/main/java/bokjak/bokjakserver/common/exception/StatusCode.java
+++ b/src/main/java/bokjak/bokjakserver/common/exception/StatusCode.java
@@ -16,6 +16,7 @@ public enum StatusCode {
     METHOD_NOT_ALLOWED(405, 9020, "method not allowed."),
     HTTP_CLIENT_ERROR(400, 9030, "http client error."),
     INVALID_REQUEST_PARAM(400, 9100, "invalid request param."),
+    NOT_FOUND_URL(404, 9110, "not found url request"),
 
     AWS_S3_UPLOAD_FAIL(400, 9040, "AWS S3 upload fail."),
     AWS_S3_DELETE_FAIL(400, 9050, "AWS S3 delete fail."),


### PR DESCRIPTION
## PR 요약
기존에 잘못된 url 요청하면 401 error 나던 것을 404로 catch했습니다.

## 구현한 내용 또는 수정한 내용

## 추가로 알리고 싶은 내용
spring security 때문에 만약 잘못된 url이지만 token이 존재하지 않는다면 401로 내려가고 있습니다.
잘못된 url이면 인증도 시도안하게 하는 것은 리펙토링에서 수정 예정입니다.

## 관련 이슈

## 체크리스트

- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  WBS 업데이트해주세요. (제목에 WBS 번호 달아주세요)
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요!
