### PR TITLE
fix: 로케이션 ORDER BY id 누락

### DIFF
--- a/src/main/java/bokjak/bokjakserver/domain/location/repository/LocationRepositoryImpl.java
+++ b/src/main/java/bokjak/bokjakserver/domain/location/repository/LocationRepositoryImpl.java
@@ -46,7 +46,7 @@ public class LocationRepositoryImpl implements LocationRepositoryCustom {
                         ? gtCursorId(cursorId)
                         : gtCursor(cursorId, congestionLevelSortOrder, cursorCongestionLevel))
                 .where(inLocationCategoryId(categoryIds))
-                .orderBy(specifyCongestionSortOrder(congestionLevelSortOrder), location.id.asc())
+                .orderBy(specifyCongestionSortOrder(congestionLevelSortOrder), location.id.asc())// 혼잡도, location_id 오름차순
                 .limit(pageable.getPageSize());
 
         return PageableExecutionUtils.getPage(
@@ -60,6 +60,7 @@ public class LocationRepositoryImpl implements LocationRepositoryCustom {
     public Page<Location> getLocations(Pageable pageable,Long cursorId) {
         JPAQuery<Location> query = queryFactory.selectFrom(location)
                 .where(gtCursorId(cursorId))
+                .orderBy(location.id.asc())// location_id 오름차순
                 .limit(pageable.getPageSize());
 
         return PageableExecutionUtils.getPage(
@@ -75,7 +76,7 @@ public class LocationRepositoryImpl implements LocationRepositoryCustom {
         JPAQuery<Location> query = selectLocationsBasedOnCongestionPrefix()
                 .leftJoin(location.weeklyCongestionStatisticList, weeklyCongestionStatistic)
                 .where(weeklyCongestionStatistic.createdAt.between(start, end))
-                .orderBy(weeklyCongestionStatistic.averageCongestionLevel.asc())
+                .orderBy(weeklyCongestionStatistic.averageCongestionLevel.asc(), location.id.asc()) // 평균 혼잡도 오름차순, location_id 오름차순
                 .limit(pageable.getPageSize());
 
         return PageableExecutionUtils.getPage(
@@ -90,6 +91,7 @@ public class LocationRepositoryImpl implements LocationRepositoryCustom {
         JPAQuery<Location> query = selectLocationsBasedOnCongestionPrefix()
                 .where(locationBookmark.user.id.eq(userId))// 특정 user의 Bookmark와 JOIN
                 .where(gtCursorId(cursorId))
+                .orderBy(location.id.asc()) // location_id 오름차순
                 .limit(pageable.getPageSize());
 
         return PageableExecutionUtils.getPage(


### PR DESCRIPTION
## PR 요약
누락된 정렬 부분 추가
 
## 구현한 내용 또는 수정한 내용

## 추가로 알리고 싶은 내용
기본적으로 PK 오름차순 정렬이 될 줄 알았는데, JOIN이 많이 되어서 기준이 바뀌었나 봅니다. (정확한 원리 파악은 안 된 상태. order by 부를 추가하면 해결되는건 확실)

## 관련 이슈

## 체크리스트

- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  WBS 업데이트해주세요. (제목에 WBS 번호 달아주세요)
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요!
