### PR TITLE
fix: slice limit +1 누락

### DIFF
--- a/src/main/java/bokjak/bokjakserver/domain/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/bokjak/bokjakserver/domain/comment/repository/CommentRepositoryImpl.java
@@ -37,7 +37,7 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                                 .from(userBlockUser)
                                 .where(userBlockUser.blockerUser.id.eq(userId))))
                         .and(gtCursorId(cursorId)))
-                .limit(pageable.getPageSize());
+                .limit(CustomSliceExecutionUtils.buildSliceLimit(pageable.getPageSize()));
 
         return CustomSliceExecutionUtils.getSlice(query.fetch(), pageable);
     }
@@ -54,7 +54,7 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                                 .from(userBlockUser)
                                 .where(userBlockUser.blockerUser.id.eq(userId))))
                         .and(gtCursorId(cursorId)))
-                .limit(CustomSliceExecutionUtils.makeSliceLimit(pageable));
+                .limit(CustomSliceExecutionUtils.buildSliceLimit(pageable.getPageSize()));
 
         return CustomSliceExecutionUtils.getSlice(query.fetch(), pageable);
     }

--- a/src/main/java/bokjak/bokjakserver/util/CustomSliceExecutionUtils.java
+++ b/src/main/java/bokjak/bokjakserver/util/CustomSliceExecutionUtils.java
@@ -9,15 +9,21 @@ import java.util.List;
 public class CustomSliceExecutionUtils {
     public static <T> Slice<T> getSlice(List<T> content, Pageable pageable) {
         boolean hasNext = false;
+
+        System.out.println("content.size() = " + content.size());
+        System.out.println("pageable.getPageSize() = " + pageable.getPageSize());
+
         if (content.size() > pageable.getPageSize()) {  // content.size가 최대일 경우: 항상 page size + 1 이고 다음 레코드가 있다.
             content.remove(pageable.getPageSize()); // limit걸 때 +1 했던 마지막 레코드를 삭제
             hasNext = true;
         }
 
+        System.out.println("hasNext = " + hasNext);
+
         return new SliceImpl<>(content, pageable, hasNext);
     }
 
-    public static int makeSliceLimit(Pageable pageable) {   // 언제나 요청한 size + 1개 조회
-        return pageable.getPageSize() + 1;
+    public static int buildSliceLimit(int size) {   // 언제나 요청한 size + 1개 조회
+        return size + 1;
     }
 }


### PR DESCRIPTION
## PR 요약
Slice로 리팩토링한 후에, limit 절에서 Pageable size +1 하는 로직을 댓글 조회에서 누락
-> 추가

## 구현한 내용 또는 수정한 내용

## 추가로 알리고 싶은 내용

## 관련 이슈

## 체크리스트

- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  WBS 업데이트해주세요. (제목에 WBS 번호 달아주세요)
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요!
