### PR TITLE
fix: 혼잡도 일간 통계 9시 이후 데이터만 응답

### DIFF
--- a/src/main/java/bokjak/bokjakserver/common/constant/GlobalConstants.java
+++ b/src/main/java/bokjak/bokjakserver/common/constant/GlobalConstants.java
@@ -36,6 +36,9 @@ public class GlobalConstants {
      * Location
      */
     public static final String DATE_FORMAT = "yyyy-MM-dd";
+    public static final String DATE_FORMAT_YYYY_MM_DD_HH_MM_SS = "yyyy-MM-dd HH:mm:ss";
+    public static final String DATE_FORMAT_YYYY_MM_DD_HH_MM = "yyyy-MM-dd HH:mm";
+    public static final String DATE_FORMAT_YYYY_MM_DD = "yyyy-MM-dd";
     public static final int TOP_LOCATIONS_SIZE = 5;
     public static final String CONTENT_DATA = "statistics";
     public static final String CONTENT_HOUR = "time";

--- a/src/main/java/bokjak/bokjakserver/domain/ban/dto/BanDto.java
+++ b/src/main/java/bokjak/bokjakserver/domain/ban/dto/BanDto.java
@@ -1,11 +1,12 @@
 package bokjak.bokjakserver.domain.ban.dto;
 
+import bokjak.bokjakserver.common.constant.GlobalConstants;
 import bokjak.bokjakserver.domain.ban.model.Ban;
 import lombok.Builder;
 
 import java.util.List;
 
-import static bokjak.bokjakserver.util.CustomDateUtils.customDateFormatOnlyDate;
+import static bokjak.bokjakserver.util.CustomDateUtils.customDateFormat;
 
 public class BanDto {
 
@@ -16,14 +17,15 @@ public class BanDto {
             String banEndedAt
     ) {
         @Builder
-        public BanResponse {}
+        public BanResponse {
+        }
 
-        public static BanResponse of (Ban ban) {
+        public static BanResponse of(Ban ban) {
             return BanResponse.builder()
                     .title(ban.getTitle())
                     .content(ban.getContent())
-                    .banStartAt(customDateFormatOnlyDate(ban.getBanStartedAt()))
-                    .banEndedAt(customDateFormatOnlyDate(ban.getBanEndedAt()))
+                    .banStartAt(customDateFormat(ban.getBanStartedAt(), GlobalConstants.DATE_FORMAT_YYYY_MM_DD))
+                    .banEndedAt(customDateFormat(ban.getBanEndedAt(), GlobalConstants.DATE_FORMAT_YYYY_MM_DD))
                     .build();
         }
     }
@@ -32,7 +34,8 @@ public class BanDto {
             List<BanResponse> banList
     ) {
         @Builder
-        public BanListResponse {}
+        public BanListResponse {
+        }
 
         public static BanListResponse of(List<BanResponse> banList) {
             return BanListResponse.builder()

--- a/src/main/java/bokjak/bokjakserver/domain/comment/dto/CommentDto.java
+++ b/src/main/java/bokjak/bokjakserver/domain/comment/dto/CommentDto.java
@@ -1,5 +1,6 @@
 package bokjak.bokjakserver.domain.comment.dto;
 
+import bokjak.bokjakserver.common.constant.GlobalConstants;
 import bokjak.bokjakserver.domain.comment.model.Comment;
 import bokjak.bokjakserver.domain.spot.model.Spot;
 import bokjak.bokjakserver.domain.user.model.User;
@@ -67,8 +68,8 @@ public class CommentDto {
                             .childCount(comment.isParent() ? comment.getChildList().size() : 0) // 대댓글의 경우 항상 0
                             .id(comment.getId())
                             .content(comment.getContent())
-                            .createdAt(CustomDateUtils.customDateFormatYMDHM(comment.getCreatedAt()))
-                            .updatedAt(CustomDateUtils.customDateFormatYMDHM(comment.getUpdatedAt()))
+                            .createdAt(CustomDateUtils.customDateFormat(comment.getCreatedAt(), GlobalConstants.DATE_FORMAT_YYYY_MM_DD_HH_MM))
+                            .updatedAt(CustomDateUtils.customDateFormat(comment.getUpdatedAt(), GlobalConstants.DATE_FORMAT_YYYY_MM_DD_HH_MM))
                             .userId(author.getId())
                             .userNickname(author.getNickname())
                             .userProfileImageUrl(author.getProfileImageUrl())

--- a/src/main/java/bokjak/bokjakserver/domain/comment/dto/CommentDto.java
+++ b/src/main/java/bokjak/bokjakserver/domain/comment/dto/CommentDto.java
@@ -3,11 +3,10 @@ package bokjak.bokjakserver.domain.comment.dto;
 import bokjak.bokjakserver.domain.comment.model.Comment;
 import bokjak.bokjakserver.domain.spot.model.Spot;
 import bokjak.bokjakserver.domain.user.model.User;
+import bokjak.bokjakserver.util.CustomDateUtils;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
-
-import java.time.LocalDateTime;
 
 import static bokjak.bokjakserver.common.constant.ConstraintConstants.COMMENT_CONTENT_MAX_LENGTH;
 
@@ -51,8 +50,8 @@ public class CommentDto {
             int childCount,
             Long id,
             String content,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
+            String createdAt,
+            String updatedAt,
             Long userId,
             String userNickname,
             String userProfileImageUrl,
@@ -68,8 +67,8 @@ public class CommentDto {
                             .childCount(comment.isParent() ? comment.getChildList().size() : 0) // 대댓글의 경우 항상 0
                             .id(comment.getId())
                             .content(comment.getContent())
-                            .createdAt(comment.getCreatedAt())
-                            .updatedAt(comment.getUpdatedAt())
+                            .createdAt(CustomDateUtils.customDateFormatYMDHM(comment.getCreatedAt()))
+                            .updatedAt(CustomDateUtils.customDateFormatYMDHM(comment.getUpdatedAt()))
                             .userId(author.getId())
                             .userNickname(author.getNickname())
                             .userProfileImageUrl(author.getProfileImageUrl())

--- a/src/main/java/bokjak/bokjakserver/domain/congestion/dto/CongestionDto.java
+++ b/src/main/java/bokjak/bokjakserver/domain/congestion/dto/CongestionDto.java
@@ -18,8 +18,10 @@ public class CongestionDto {
         public static DailyCongestionStatisticResponse of(
                 DailyCongestionStatistic dailyCongestionStatistic
         ) {
-            List<DailyCongestionRecord> records = dailyCongestionStatistic.getContent().get(GlobalConstants.CONTENT_DATA)
-                    .stream().map(DailyCongestionRecord::of).toList();
+            List<DailyCongestionRecord> records = dailyCongestionStatistic.getContent().get(GlobalConstants.CONTENT_DATA).stream()
+                    .filter(it->it.get(GlobalConstants.CONTENT_HOUR) >= GlobalConstants.CONGESTION_STATISTIC_START_TIME) // 9시 이후 데이터만 응답
+                    .map(DailyCongestionRecord::of)
+                    .toList();
 
             return DailyCongestionStatisticResponse.builder()
                     .id(dailyCongestionStatistic.getId())

--- a/src/main/java/bokjak/bokjakserver/domain/notification/dto/NotificationDto.java
+++ b/src/main/java/bokjak/bokjakserver/domain/notification/dto/NotificationDto.java
@@ -7,10 +7,9 @@ import bokjak.bokjakserver.domain.spot.model.Spot;
 import bokjak.bokjakserver.domain.user.model.User;
 import lombok.Builder;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
-import static bokjak.bokjakserver.util.CustomDateUtils.customDateFormat;
+import static bokjak.bokjakserver.util.CustomDateUtils.customDateFormatYMDHMS;
 
 public class NotificationDto {
     public record NotifyParams(
@@ -104,7 +103,7 @@ public class NotificationDto {
                     .redirectTargetId(notification.getRedirectTargetId())
                     .title(notification.getTitle())
                     .body(notification.getContent())
-                    .createdAt(customDateFormat(notification.getCreatedAt()))
+                    .createdAt(customDateFormatYMDHMS(notification.getCreatedAt()))
                     .isRead(notification.isRead())
                     .build();
         }

--- a/src/main/java/bokjak/bokjakserver/domain/notification/dto/NotificationDto.java
+++ b/src/main/java/bokjak/bokjakserver/domain/notification/dto/NotificationDto.java
@@ -1,5 +1,6 @@
 package bokjak.bokjakserver.domain.notification.dto;
 
+import bokjak.bokjakserver.common.constant.GlobalConstants;
 import bokjak.bokjakserver.domain.comment.model.Comment;
 import bokjak.bokjakserver.domain.notification.model.Notification;
 import bokjak.bokjakserver.domain.notification.model.NotificationType;
@@ -9,7 +10,7 @@ import lombok.Builder;
 
 import java.util.List;
 
-import static bokjak.bokjakserver.util.CustomDateUtils.customDateFormatYMDHMS;
+import static bokjak.bokjakserver.util.CustomDateUtils.customDateFormat;
 
 public class NotificationDto {
     public record NotifyParams(
@@ -103,7 +104,7 @@ public class NotificationDto {
                     .redirectTargetId(notification.getRedirectTargetId())
                     .title(notification.getTitle())
                     .body(notification.getContent())
-                    .createdAt(customDateFormatYMDHMS(notification.getCreatedAt()))
+                    .createdAt(customDateFormat(notification.getCreatedAt(), GlobalConstants.DATE_FORMAT_YYYY_MM_DD_HH_MM_SS))
                     .isRead(notification.isRead())
                     .build();
         }

--- a/src/main/java/bokjak/bokjakserver/domain/spot/dto/SpotDto.java
+++ b/src/main/java/bokjak/bokjakserver/domain/spot/dto/SpotDto.java
@@ -5,12 +5,12 @@ import bokjak.bokjakserver.domain.location.model.Location;
 import bokjak.bokjakserver.domain.spot.model.Spot;
 import bokjak.bokjakserver.domain.spot.model.SpotImage;
 import bokjak.bokjakserver.domain.user.model.User;
+import bokjak.bokjakserver.util.CustomDateUtils;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static bokjak.bokjakserver.common.constant.ConstraintConstants.*;
@@ -96,8 +96,8 @@ public class SpotDto {
             String address,
             String content,
             List<String> imageUrls,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
+            String createdAt,
+            String updatedAt,
             Long locationId,
             String locationName,
             Long spotCategoryId,
@@ -118,8 +118,8 @@ public class SpotDto {
                     .title(spot.getTitle())
                     .address(spot.getAddress())
                     .content(spot.getContent())
-                    .createdAt(spot.getCreatedAt())
-                    .updatedAt(spot.getUpdatedAt())
+                    .createdAt(CustomDateUtils.customDateFormatYMDHM(spot.getCreatedAt()))
+                    .updatedAt(CustomDateUtils.customDateFormatYMDHM(spot.getUpdatedAt()))
                     .locationId(spot.getLocation().getId())
                     .locationName(spot.getLocation().getName())
                     .spotCategoryId(spot.getSpotCategory().getId())

--- a/src/main/java/bokjak/bokjakserver/domain/spot/dto/SpotDto.java
+++ b/src/main/java/bokjak/bokjakserver/domain/spot/dto/SpotDto.java
@@ -1,5 +1,6 @@
 package bokjak.bokjakserver.domain.spot.dto;
 
+import bokjak.bokjakserver.common.constant.GlobalConstants;
 import bokjak.bokjakserver.domain.category.model.SpotCategory;
 import bokjak.bokjakserver.domain.location.model.Location;
 import bokjak.bokjakserver.domain.spot.model.Spot;
@@ -118,8 +119,8 @@ public class SpotDto {
                     .title(spot.getTitle())
                     .address(spot.getAddress())
                     .content(spot.getContent())
-                    .createdAt(CustomDateUtils.customDateFormatYMDHM(spot.getCreatedAt()))
-                    .updatedAt(CustomDateUtils.customDateFormatYMDHM(spot.getUpdatedAt()))
+                    .createdAt(CustomDateUtils.customDateFormat(spot.getCreatedAt(), GlobalConstants.DATE_FORMAT_YYYY_MM_DD_HH_MM))
+                    .updatedAt(CustomDateUtils.customDateFormat(spot.getUpdatedAt(), GlobalConstants.DATE_FORMAT_YYYY_MM_DD_HH_MM))
                     .locationId(spot.getLocation().getId())
                     .locationName(spot.getLocation().getName())
                     .spotCategoryId(spot.getSpotCategory().getId())

--- a/src/main/java/bokjak/bokjakserver/util/CustomDateUtils.java
+++ b/src/main/java/bokjak/bokjakserver/util/CustomDateUtils.java
@@ -31,15 +31,8 @@ public class CustomDateUtils {
         ).toLocalDateTime();
     }
 
-    public static String customDateFormatYMDHMS(LocalDateTime localDateTime) {
-        return localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    public static String customDateFormat(LocalDateTime localDateTime, String pattern) {
+        return localDateTime.format(DateTimeFormatter.ofPattern(pattern));
     }
 
-    public static String customDateFormatYMDHM(LocalDateTime localDateTime) {
-        return localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
-    }
-
-    public static String customDateFormatOnlyDate(LocalDateTime localDateTime) {
-        return localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-    }
 }

--- a/src/main/java/bokjak/bokjakserver/util/CustomDateUtils.java
+++ b/src/main/java/bokjak/bokjakserver/util/CustomDateUtils.java
@@ -31,8 +31,12 @@ public class CustomDateUtils {
         ).toLocalDateTime();
     }
 
-    public static String customDateFormat(LocalDateTime localDateTime) {
+    public static String customDateFormatYMDHMS(LocalDateTime localDateTime) {
         return localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    public static String customDateFormatYMDHM(LocalDateTime localDateTime) {
+        return localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
     }
 
     public static String customDateFormatOnlyDate(LocalDateTime localDateTime) {


### PR DESCRIPTION
## PR 요약
YMDHM 형식 유틸 추가

혼잡도 통계 DTO 수정
스팟, 댓글 상세 조회 DTO 수정

## 구현한 내용 또는 수정한 내용
혼잡도 일간 통계 9시 이후 데이터만 응답하도록 수정

스팟, 댓글 조회 DTO : 생성일자, 수정일자 -> YMDHM (yyyy-mm-dd HH:MM) 포맷으로 수정

## 추가로 알리고 싶은 내용

## 관련 이슈

## 체크리스트

- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  WBS 업데이트해주세요. (제목에 WBS 번호 달아주세요)
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요!
