### PR TITLE
refactor: 특정 프로파일(local)에서만 더미 파일 작동하도록 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,6 @@ application-prod.yml
 memo.md
 /src/main/resources/buzzzzing-firebase-private-key.json
 
-/src/main/java/bokjak/bokjakserver/common/dummy/LocationDummy.java
-
-
 ### STS ###
 .apt_generated
 .classpath

--- a/src/main/java/bokjak/bokjakserver/common/dummy/BuzzingDummy.java
+++ b/src/main/java/bokjak/bokjakserver/common/dummy/BuzzingDummy.java
@@ -1,0 +1,17 @@
+package bokjak.bokjakserver.common.dummy;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Transactional
+@Profile({"local"}) // 특정 프로파일에만 더미 파일 작동
+@interface BuzzingDummy {
+}

--- a/src/main/java/bokjak/bokjakserver/common/dummy/CategoryDummy.java
+++ b/src/main/java/bokjak/bokjakserver/common/dummy/CategoryDummy.java
@@ -1,28 +1,27 @@
 package bokjak.bokjakserver.common.dummy;
 
-import bokjak.bokjakserver.domain.category.service.CategoryService;
 import bokjak.bokjakserver.domain.category.repository.LocationCategoryRepository;
+import bokjak.bokjakserver.domain.category.service.CategoryService;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import static bokjak.bokjakserver.common.dummy.DummyLocationCategory.*;
 import static bokjak.bokjakserver.common.dummy.DummySpotCategory.*;
 
 @Slf4j
-@Component("categoryDummy")
 @RequiredArgsConstructor
-@Transactional
+@Component("categoryDummy")
+@BuzzingDummy
 public class CategoryDummy {
     private final CategoryService categoryService;
     private final LocationCategoryRepository locationCategoryRepository;
 
     @PostConstruct
-    public void init(){
+    public void init() {
         if (locationCategoryRepository.count() > 0) {
-            log.info("[2] 카테고리가 이미 존재");
+            log.info("[categoryDummy] 카테고리가 이미 존재");
             return;
         }
 
@@ -41,6 +40,6 @@ public class CategoryDummy {
         categoryService.createDummySpotCategory(PLAY);
         categoryService.createDummySpotCategory(RESTAURANT);
 
-        log.info("[1] 카테고리 더미 생성 완료");
+        log.info("[categoryDummy] 카테고리 더미 생성 완료");
     }
 }

--- a/src/main/java/bokjak/bokjakserver/common/dummy/CommentDummy.java
+++ b/src/main/java/bokjak/bokjakserver/common/dummy/CommentDummy.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -19,7 +18,7 @@ import java.util.List;
 @Component("commentDummy")
 @DependsOn("spotDummy")
 @RequiredArgsConstructor
-@Transactional
+@BuzzingDummy
 public class CommentDummy {
     private final UserRepository userRepository;
     private final SpotRepository spotRepository;
@@ -28,10 +27,10 @@ public class CommentDummy {
     @PostConstruct
     public void init() {
         if (commentRepository.count() > 0) {
-            log.info("[6] 댓글 데이터가 이미 존재");
+            log.info("[commentDummy] 댓글 데이터가 이미 존재");
         } else {
             createComments();
-            log.info("[6] 댓글 더미 생성 완료");
+            log.info("[commentDummy] 댓글 더미 생성 완료");
         }
     }
 

--- a/src/main/java/bokjak/bokjakserver/common/dummy/CongestionDummy.java
+++ b/src/main/java/bokjak/bokjakserver/common/dummy/CongestionDummy.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -24,7 +23,7 @@ import java.util.Map;
 @Component("congestionDummy")
 @DependsOn("userDummy")
 @RequiredArgsConstructor
-@Transactional
+@BuzzingDummy
 public class CongestionDummy {
     // 개발용. 배포 이후엔 Django 혼잡도 서버에 의존
     private final CongestionRepository congestionRepository;
@@ -35,11 +34,11 @@ public class CongestionDummy {
     @PostConstruct
     public void init() {
         if (congestionRepository.count() > 0) {
-            log.info("[4] 혼잡도 데이터가 이미 존재");
+            log.info("[congestionDummy] 혼잡도 데이터가 이미 존재");
         } else {
             createCongestions();
             createCongestionStatistics();
-            log.info("[4] 혼잡도 더미 생성 완료");
+            log.info("[congestionDummy] 혼잡도 더미 생성 완료");
         }
     }
 

--- a/src/main/java/bokjak/bokjakserver/common/dummy/LocationDummy.java
+++ b/src/main/java/bokjak/bokjakserver/common/dummy/LocationDummy.java
@@ -1,0 +1,78 @@
+package bokjak.bokjakserver.common.dummy;
+
+import bokjak.bokjakserver.domain.category.model.LocationCategory;
+import bokjak.bokjakserver.domain.category.repository.LocationCategoryRepository;
+import bokjak.bokjakserver.domain.location.model.Location;
+import bokjak.bokjakserver.domain.location.repository.LocationRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component("locationDummy")
+@DependsOn("categoryDummy")
+@RequiredArgsConstructor
+@BuzzingDummy
+public class LocationDummy {
+    private final LocationCategoryRepository locationCategoryRepository;
+    private final LocationRepository locationRepository;
+
+    @PostConstruct
+    public void init() {
+        if (locationRepository.count() > 0) {
+            log.info("[locationDummy] 로케이션 데이터가 이미 존재");
+        } else {
+            createLocations();
+            log.info("[locationDummy] 로케이션 더미 생성 완료");
+        }
+    }
+
+    private void createLocations() {
+        List<LocationCategory> allCategory = locationCategoryRepository.findAll();
+
+        locationRepository.save(Location.builder().name("서울 암사동 유적").locationCategory(allCategory.get(3)).build());
+        locationRepository.save(Location.builder().name("창덕궁종묘").locationCategory(allCategory.get(3)).build());
+        locationRepository.save(Location.builder().name("가산디지털단지역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("강남역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("건대입구역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("고덕역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("고속터미널역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("교대역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("구로디지털단지역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("구로역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("군자역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("남구로역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("대림역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("동대문역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("뚝섬역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("미아사거리역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("발산역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("북한산우이역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("사당역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("삼각지역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("서울대입구역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("선릉역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("성신여대입구역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("수유역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("신논현역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("신도림역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("신림역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("신촌이대역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("양재역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("역삼역").locationCategory(allCategory.get(0)).build());
+        locationRepository.save(Location.builder().name("강서한강공원").locationCategory(allCategory.get(4)).build());
+        locationRepository.save(Location.builder().name("고척돔").locationCategory(allCategory.get(6)).build());
+        locationRepository.save(Location.builder().name("광나루한강공원").locationCategory(allCategory.get(4)).build());
+        locationRepository.save(Location.builder().name("난지한강공원").locationCategory(allCategory.get(4)).build());
+        locationRepository.save(Location.builder().name("노들섬").locationCategory(allCategory.get(6)).build());
+        locationRepository.save(Location.builder().name("뚝섬한강공원").locationCategory(allCategory.get(4)).build());
+        locationRepository.save(Location.builder().name("망원한강공원").locationCategory(allCategory.get(4)).build());
+        locationRepository.save(Location.builder().name("불광천").locationCategory(allCategory.get(6)).build());
+        locationRepository.save(Location.builder().name("서울광장").locationCategory(allCategory.get(4)).build());
+        locationRepository.save(Location.builder().name("서울대공원").locationCategory(allCategory.get(4)).build());
+    }
+}

--- a/src/main/java/bokjak/bokjakserver/common/dummy/SpotDummy.java
+++ b/src/main/java/bokjak/bokjakserver/common/dummy/SpotDummy.java
@@ -15,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +23,7 @@ import java.util.List;
 @Component("spotDummy")
 @DependsOn({"userDummy", "congestionDummy"})
 @RequiredArgsConstructor
-@Transactional
+@BuzzingDummy
 public class SpotDummy {
     private final LocationRepository locationRepository;
     private final SpotCategoryRepository spotCategoryRepository;
@@ -35,16 +34,16 @@ public class SpotDummy {
     @PostConstruct
     public void init() {
         if (spotRepository.count() > 0) {
-            log.info("[5] 스팟 데이터가 이미 존재");
+            log.info("[spotDummy] 스팟 데이터가 이미 존재");
         } else {
             createSpots();
-            log.info("[5] 스팟 더미 생성 완료");
+            log.info("[spotDummy] 스팟 더미 생성 완료");
         }
         if (spotImageRepository.count() > 0) {
-            log.info("[5-1] 스팟 이미지 데이터가 이미 존재");
+            log.info("[spotDummy-1] 스팟 이미지 데이터가 이미 존재");
         } else {
             createSpotImages();
-            log.info("[5-1] 스팟 더미 생성 완료");
+            log.info("[spotDummy-1] 스팟 더미 생성 완료");
         }
     }
 

--- a/src/main/java/bokjak/bokjakserver/common/dummy/UserDummy.java
+++ b/src/main/java/bokjak/bokjakserver/common/dummy/UserDummy.java
@@ -6,24 +6,23 @@ import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 
 @Slf4j
 @Component("userDummy")
 @RequiredArgsConstructor
-@Transactional
+@BuzzingDummy
 public class UserDummy {
     private final UserRepository userRepository;
 
     @PostConstruct
     public void init() {
         if (userRepository.count() > 0) {
-            log.info("[1] 더미 유저가 이미 존재합니다.");
-        }else {
+            log.info("[userDummy] 더미 유저가 이미 존재합니다.");
+        } else {
             createUsers();
-            log.info("[1] 더미 유저 생성완료");
+            log.info("[userDummy] 더미 유저 생성완료");
         }
     }
 
@@ -55,7 +54,7 @@ public class UserDummy {
         for (int i = 0; i < 10; i++) {
             SignUpRequest dummyUserForm = SignUpRequest.builder()
                     .build();
-            userRepository.save(dummyUserForm.toDummy(nicknames.get(i)+"@naver.com", nicknames.get(i), i+"@KAKAO", imageUrls.get(i)));
+            userRepository.save(dummyUserForm.toDummy(nicknames.get(i) + "@naver.com", nicknames.get(i), i + "@KAKAO", imageUrls.get(i)));
         }
     }
 


### PR DESCRIPTION
## PR 요약
더미 파일 불안해서 local 프로파일에서만 돌아가도록 변경

## 구현한 내용 또는 수정한 내용
커스텀 어노테이션을 만들어보았음. [참고](https://velog.io/@potato_song/Java-%EC%96%B4%EB%85%B8%ED%85%8C%EC%9D%B4%EC%85%98-%EC%BB%A4%EC%8A%A4%ED%85%80-%EC%96%B4%EB%85%B8%ED%85%8C%EC%9D%B4%EC%85%98-%EB%A7%8C%EB%93%A4%EA%B8%B0)

더미 클래스는 해당 어노테이션을 받으면 자동적으로 local 프로파일에서만 동작합니다 

## 추가로 알리고 싶은 내용

## 관련 이슈

## 체크리스트

- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  WBS 업데이트해주세요. (제목에 WBS 번호 달아주세요)
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요!
