### PR TITLE
fix: 코멘트 ORDER BY 오류

### DIFF
--- a/src/main/java/bokjak/bokjakserver/domain/spot/repository/SpotRepositoryImpl.java
+++ b/src/main/java/bokjak/bokjakserver/domain/spot/repository/SpotRepositoryImpl.java
@@ -106,7 +106,7 @@ public class SpotRepositoryImpl implements SpotRepositoryCustom {
                         .from(comment)
                         .where(comment.user.id.eq(userId))))
                 .where(ltCursorId(cursorId))    // 최신순
-                .orderBy(spot.id.desc())
+                .orderBy(comment.id.desc())
                 .limit(pageable.getPageSize());
 
         return PageableExecutionUtils.getPage(
@@ -133,6 +133,7 @@ public class SpotRepositoryImpl implements SpotRepositoryCustom {
                 .join(spot.location, location).fetchJoin()
                 .join(spot.spotCategory, spotCategory).fetchJoin()
                 .leftJoin(spot.spotBookmarkList, spotBookmark).fetchJoin()
+                .join(spot.commentList, comment)
                 .leftJoin(spot.spotImageList, spotImage)
                 .where(spot.user.id.notIn(JPAExpressions.select(userBlockUser.blockedUser.id)  // 차단한 유저 제외
                         .from(userBlockUser)

--- a/src/main/java/bokjak/bokjakserver/domain/spot/repository/SpotRepositoryImpl.java
+++ b/src/main/java/bokjak/bokjakserver/domain/spot/repository/SpotRepositoryImpl.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import static bokjak.bokjakserver.domain.bookmark.model.QSpotBookmark.spotBookmark;
@@ -39,7 +40,7 @@ public class SpotRepositoryImpl implements SpotRepositoryCustom {
             Long locationId,
             List<Long> categoryIds
     ) {
-        JPAQuery<Spot> query = selectSpotsExceptBlockedAuthorsPrefix(userId)
+        JPAQuery<Spot> query = selectBigSpotsExceptBlockedAuthorsPrefix(userId)
                 .where(eqLocationId(locationId))// 특정 로케이션의
                 .where(inSpotCategoryId(categoryIds))
                 .where(ltCursorId(cursorId))    // 최신순
@@ -55,7 +56,7 @@ public class SpotRepositoryImpl implements SpotRepositoryCustom {
 
     @Override
     public Page<Spot> findAllByCategoriesExceptBlockedAuthors(Long userId, Pageable pageable, Long cursorId, List<Long> categoryIds) {
-        JPAQuery<Spot> query = selectSpotsExceptBlockedAuthorsPrefix(userId)
+        JPAQuery<Spot> query = selectBigSpotsExceptBlockedAuthorsPrefix(userId)
                 .where(inSpotCategoryId(categoryIds))   // 특정 카테고리의
                 .where(ltCursorId(cursorId))    // 최신순
                 .orderBy(spot.id.desc())
@@ -70,7 +71,7 @@ public class SpotRepositoryImpl implements SpotRepositoryCustom {
 
     @Override
     public Page<Spot> findAllBookmarked(Pageable pageable, Long cursorId, Long userId) {
-        JPAQuery<Spot> query = selectSpotsExceptBlockedAuthorsPrefix(userId)
+        JPAQuery<Spot> query = selectBigSpotsExceptBlockedAuthorsPrefix(userId)
                 .where(spotBookmark.user.id.eq(userId))// 현재 유저가 북마크한
                 .where(ltCursorId(cursorId))    // 최신순
                 .orderBy(spot.id.desc())
@@ -100,13 +101,16 @@ public class SpotRepositoryImpl implements SpotRepositoryCustom {
 
     @Override
     public Page<Spot> findAllCommentedByMeExceptBlockedAuthors(Pageable pageable, Long cursorId, Long userId) {
-        JPAQuery<Spot> query = selectSpotsExceptBlockedAuthorsPrefix(userId)
-                .where(spot.id.in(JPAExpressions    // 현재 유저가 작성한 댓글들의 부모 스팟들
-                        .select(comment.spot.id)
-                        .from(comment)
-                        .where(comment.user.id.eq(userId))))
-                .where(ltCursorId(cursorId))    // 최신순
-                .orderBy(comment.id.desc())
+        // TODO: 응답값으로 각 Spot의 lastCommentId 주고, 받기 -> 쿼리 1회 감소
+        Long latestCommentId = findLatestCommentIdBySpotId(cursorId);
+
+        // TODO: JOIN을 못해서 default_batch_size 쿼리가 나가고 있다. 개선해보자
+        JPAQuery<Spot> query = queryFactory
+                .select(comment.spot).from(comment)
+                .where(comment.user.id.eq(userId))  // 해당 유저의 댓글만 조회
+                .groupBy(comment.spot.id)
+                .having(ltMaxCommentId(latestCommentId))
+                .orderBy(comment.id.max().desc())
                 .limit(pageable.getPageSize());
 
         return PageableExecutionUtils.getPage(
@@ -114,6 +118,20 @@ public class SpotRepositoryImpl implements SpotRepositoryCustom {
                 pageable,
                 findAllCommentedByMeExceptBlockedAuthorsCountQuery(userId)::fetchOne
         );
+    }
+
+    private Long findLatestCommentIdBySpotId(Long cursorId) {
+        if (Objects.isNull(cursorId)) {
+            return null;
+        } else {
+            Long latestCommentId = queryFactory.select(comment.id).from(comment)
+                    .where(comment.spot.id.eq(cursorId))
+                    .orderBy(comment.id.desc())
+                    .fetchFirst();
+            if (Objects.isNull(latestCommentId)) return null;
+
+            return latestCommentId;
+        }
     }
 
     @Override
@@ -129,11 +147,37 @@ public class SpotRepositoryImpl implements SpotRepositoryCustom {
      **/
     private JPAQuery<Spot> selectSpotsExceptBlockedAuthorsPrefix(Long userId) {// 일반적인 리스트 조회
         return queryFactory.selectFrom(spot)
+                // 부모 엔티티는 모두 페치 조인. bookmark, comment, imageList의 조인 여부는 caller에게 위임
+                .join(spot.user, user).fetchJoin()
+                .join(spot.location, location).fetchJoin()
+                .join(spot.spotCategory, spotCategory).fetchJoin()
+                .where(spot.user.id.notIn(JPAExpressions.select(userBlockUser.blockedUser.id)  // 차단한 유저 제외
+                        .from(userBlockUser)
+                        .where(userBlockUser.blockerUser.id.eq(userId))
+                ));
+    }
+
+    private JPAQuery<Spot> selectBigSpotsExceptBlockedAuthorsPrefix(Long userId) {// 일반적인 리스트 조회
+        return queryFactory.selectFrom(spot)
                 .join(spot.user, user).fetchJoin()
                 .join(spot.location, location).fetchJoin()
                 .join(spot.spotCategory, spotCategory).fetchJoin()
                 .leftJoin(spot.spotBookmarkList, spotBookmark).fetchJoin()
                 .join(spot.commentList, comment)
+                .leftJoin(spot.spotImageList, spotImage)
+                .where(spot.user.id.notIn(JPAExpressions.select(userBlockUser.blockedUser.id)  // 차단한 유저 제외
+                        .from(userBlockUser)
+                        .where(userBlockUser.blockerUser.id.eq(userId))
+                ));
+    }
+
+    private JPAQuery<Spot> selectSpotsCommentedByMeExceptBlockedAuthorsPrefix(Long userId) {// 마이페이지 댓글 중심 리스트 조회
+        return queryFactory.selectFrom(spot)
+                .join(spot.user, user).fetchJoin()
+                .join(spot.location, location).fetchJoin()
+                .join(spot.spotCategory, spotCategory).fetchJoin()
+                .leftJoin(spot.spotBookmarkList, spotBookmark)
+                .join(spot.commentList, comment).fetchJoin()
                 .leftJoin(spot.spotImageList, spotImage)
                 .where(spot.user.id.notIn(JPAExpressions.select(userBlockUser.blockedUser.id)  // 차단한 유저 제외
                         .from(userBlockUser)
@@ -223,6 +267,11 @@ public class SpotRepositoryImpl implements SpotRepositoryCustom {
     private BooleanExpression ltCursorId(Long cursorId) {
         if (cursorId == null || cursorId == 0) return null;
         else return spot.id.lt(cursorId);
+    }
+
+    private BooleanExpression ltMaxCommentId(Long cursorId) {
+        if (cursorId == null || cursorId == 0) return null;
+        else return comment.id.max().lt(cursorId);
     }
 
     private BooleanExpression eqLocationId(Long locationId) {

--- a/src/main/java/bokjak/bokjakserver/domain/spot/repository/SpotRepositoryImpl.java
+++ b/src/main/java/bokjak/bokjakserver/domain/spot/repository/SpotRepositoryImpl.java
@@ -40,7 +40,7 @@ public class SpotRepositoryImpl implements SpotRepositoryCustom {
             Long locationId,
             List<Long> categoryIds
     ) {
-        JPAQuery<Spot> query = selectBigSpotsExceptBlockedAuthorsPrefix(userId)
+        JPAQuery<Spot> query = selectSpotsExceptBlockedAuthorsPrefix(userId)
                 .where(eqLocationId(locationId))// 특정 로케이션의
                 .where(inSpotCategoryId(categoryIds))
                 .where(ltCursorId(cursorId))    // 최신순
@@ -56,7 +56,7 @@ public class SpotRepositoryImpl implements SpotRepositoryCustom {
 
     @Override
     public Page<Spot> findAllByCategoriesExceptBlockedAuthors(Long userId, Pageable pageable, Long cursorId, List<Long> categoryIds) {
-        JPAQuery<Spot> query = selectBigSpotsExceptBlockedAuthorsPrefix(userId)
+        JPAQuery<Spot> query = selectSpotsExceptBlockedAuthorsPrefix(userId)
                 .where(inSpotCategoryId(categoryIds))   // 특정 카테고리의
                 .where(ltCursorId(cursorId))    // 최신순
                 .orderBy(spot.id.desc())
@@ -71,7 +71,7 @@ public class SpotRepositoryImpl implements SpotRepositoryCustom {
 
     @Override
     public Page<Spot> findAllBookmarked(Pageable pageable, Long cursorId, Long userId) {
-        JPAQuery<Spot> query = selectBigSpotsExceptBlockedAuthorsPrefix(userId)
+        JPAQuery<Spot> query = selectSpotsExceptBlockedAuthorsPrefix(userId)
                 .where(spotBookmark.user.id.eq(userId))// 현재 유저가 북마크한
                 .where(ltCursorId(cursorId))    // 최신순
                 .orderBy(spot.id.desc())
@@ -101,7 +101,7 @@ public class SpotRepositoryImpl implements SpotRepositoryCustom {
 
     @Override
     public Page<Spot> findAllCommentedByMeExceptBlockedAuthors(Pageable pageable, Long cursorId, Long userId) {
-        // TODO: 응답값으로 각 Spot의 lastCommentId 주고, 받기 -> 쿼리 1회 감소
+        // TODO: 응답값에 각 Spot의 lastCommentId 추가, 요청에서 받기 -> 쿼리 1회 감소
         Long latestCommentId = findLatestCommentIdBySpotId(cursorId);
 
         // TODO: JOIN을 못해서 default_batch_size 쿼리가 나가고 있다. 개선해보자
@@ -147,37 +147,10 @@ public class SpotRepositoryImpl implements SpotRepositoryCustom {
      **/
     private JPAQuery<Spot> selectSpotsExceptBlockedAuthorsPrefix(Long userId) {// 일반적인 리스트 조회
         return queryFactory.selectFrom(spot)
-                // 부모 엔티티는 모두 페치 조인. bookmark, comment, imageList의 조인 여부는 caller에게 위임
-                .join(spot.user, user).fetchJoin()
-                .join(spot.location, location).fetchJoin()
-                .join(spot.spotCategory, spotCategory).fetchJoin()
-                .where(spot.user.id.notIn(JPAExpressions.select(userBlockUser.blockedUser.id)  // 차단한 유저 제외
-                        .from(userBlockUser)
-                        .where(userBlockUser.blockerUser.id.eq(userId))
-                ));
-    }
-
-    private JPAQuery<Spot> selectBigSpotsExceptBlockedAuthorsPrefix(Long userId) {// 일반적인 리스트 조회
-        return queryFactory.selectFrom(spot)
                 .join(spot.user, user).fetchJoin()
                 .join(spot.location, location).fetchJoin()
                 .join(spot.spotCategory, spotCategory).fetchJoin()
                 .leftJoin(spot.spotBookmarkList, spotBookmark).fetchJoin()
-                .join(spot.commentList, comment)
-                .leftJoin(spot.spotImageList, spotImage)
-                .where(spot.user.id.notIn(JPAExpressions.select(userBlockUser.blockedUser.id)  // 차단한 유저 제외
-                        .from(userBlockUser)
-                        .where(userBlockUser.blockerUser.id.eq(userId))
-                ));
-    }
-
-    private JPAQuery<Spot> selectSpotsCommentedByMeExceptBlockedAuthorsPrefix(Long userId) {// 마이페이지 댓글 중심 리스트 조회
-        return queryFactory.selectFrom(spot)
-                .join(spot.user, user).fetchJoin()
-                .join(spot.location, location).fetchJoin()
-                .join(spot.spotCategory, spotCategory).fetchJoin()
-                .leftJoin(spot.spotBookmarkList, spotBookmark)
-                .join(spot.commentList, comment).fetchJoin()
                 .leftJoin(spot.spotImageList, spotImage)
                 .where(spot.user.id.notIn(JPAExpressions.select(userBlockUser.blockedUser.id)  // 차단한 유저 제외
                         .from(userBlockUser)


### PR DESCRIPTION
## PR 요약
comment가 아닌 spot을 최신순으로 정렬하고 있었던 문제 해결

## 구현한 내용 또는 수정한 내용

## 추가로 알리고 싶은 내용
GROUP BY를 쓰고 있어서 페치조인이 안되는 이슈가 있습니다..! 추후에 성능개선해볼께요

## 관련 이슈

## 체크리스트

- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  WBS 업데이트해주세요. (제목에 WBS 번호 달아주세요)
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요!
