### PR TITLE
refactor: HTTP 캐싱 Last-Modified 

### DIFF
--- a/src/main/java/bokjak/bokjakserver/common/dto/PageResponse.java
+++ b/src/main/java/bokjak/bokjakserver/common/dto/PageResponse.java
@@ -2,7 +2,6 @@ package bokjak.bokjakserver.common.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -13,7 +12,6 @@ import java.util.List;
 
 @Builder
 @Getter
-@Slf4j
 public class PageResponse<T> {
     Long totalElements;
     boolean last;

--- a/src/main/java/bokjak/bokjakserver/common/dto/PageWithLastModified.java
+++ b/src/main/java/bokjak/bokjakserver/common/dto/PageWithLastModified.java
@@ -1,0 +1,21 @@
+package bokjak.bokjakserver.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class PageWithLastModified<T> {
+    PageResponse<T> pageResponse;
+    LocalDateTime lastModified;
+
+    public static <T> PageWithLastModified<T> of(Page<T> page, LocalDateTime lastModified) {
+        return PageWithLastModified.<T>builder()
+                .pageResponse(PageResponse.of(page))
+                .lastModified(lastModified)
+                .build();
+    }
+}

--- a/src/main/java/bokjak/bokjakserver/domain/category/controller/CategoryController.java
+++ b/src/main/java/bokjak/bokjakserver/domain/category/controller/CategoryController.java
@@ -2,14 +2,25 @@ package bokjak.bokjakserver.domain.category.controller;
 
 import bokjak.bokjakserver.common.constant.SwaggerConstants;
 import bokjak.bokjakserver.common.dto.ApiResponse;
+import bokjak.bokjakserver.domain.category.dto.CategoryDto.AllCategories;
 import bokjak.bokjakserver.domain.category.dto.CategoryDto.AllCategoryResponse;
 import bokjak.bokjakserver.domain.category.service.CategoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.ServletWebRequest;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 @RestController
 @RequestMapping("/categories")
@@ -20,7 +31,18 @@ public class CategoryController {
 
     @GetMapping
     @Operation(summary = SwaggerConstants.CATEGORY_GET_ALL, description = SwaggerConstants.CATEGORY_GET_ALL_DESCRIPTION)
-    public ApiResponse<AllCategoryResponse> getAllCategory() {
-        return ApiResponse.success(categoryService.getAllCategory());
+    public ResponseEntity<ApiResponse<AllCategoryResponse>> getAllCategory(ServletWebRequest request) {
+        AllCategories allCategories = categoryService.getAllCategory();
+        LocalDateTime lastModifiedAt = allCategories.lastModifiedAt();
+
+        // Last-Modified 검증. 같다면 304 응답
+        if (request.checkNotModified(String.valueOf(lastModifiedAt))) {
+            return null;
+        }
+
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noCache())
+                .lastModified(ZonedDateTime.of(lastModifiedAt, ZoneId.systemDefault()))
+                .body(ApiResponse.success(AllCategoryResponse.fromAllCategories(allCategories)));
     }
 }

--- a/src/main/java/bokjak/bokjakserver/domain/category/dto/CategoryDto.java
+++ b/src/main/java/bokjak/bokjakserver/domain/category/dto/CategoryDto.java
@@ -6,6 +6,7 @@ import bokjak.bokjakserver.util.enums.EnumQueryValue;
 import bokjak.bokjakserver.util.enums.EnumValue;
 import lombok.Builder;
 
+import java.time.LocalDateTime;
 import java.util.*;
 
 import static bokjak.bokjakserver.util.enums.EnumQueryValue.toEnumQueryValues;
@@ -44,6 +45,25 @@ public class CategoryDto {
     }
 
     @Builder
+    public record AllCategories(
+            List<LocationCategoryResponse> locationCategories,
+            List<SpotCategoryResponse> spotCategories,
+            LocalDateTime lastModifiedAt
+    ) {
+
+        public static AllCategories of(List<LocationCategoryResponse> locationCategories,
+                                       List<SpotCategoryResponse> spotCategories,
+                                       LocalDateTime lastModifiedAt) {
+
+            return AllCategories.builder()
+                    .locationCategories(locationCategories)
+                    .spotCategories(spotCategories)
+                    .lastModifiedAt(lastModifiedAt)
+                    .build();
+        }
+    }
+
+    @Builder
     public record AllCategoryResponse(
             List<LocationCategoryResponse> locationCategories,
             List<SpotCategoryResponse> spotCategories,
@@ -57,6 +77,15 @@ public class CategoryDto {
             return AllCategoryResponse.builder()
                     .locationCategories(locationCategories)
                     .spotCategories(spotCategories)
+                    .congestionLevelChoices(toEnumValues(CongestionLevelChoice.class))
+                    .congestionHistoricalDateChoices(toEnumQueryValues(CongestionHistoricalDateChoice.class))
+                    .build();
+        }
+
+        public static AllCategoryResponse fromAllCategories(AllCategories allCategories) {
+            return AllCategoryResponse.builder()
+                    .locationCategories(allCategories.locationCategories())
+                    .spotCategories(allCategories.spotCategories())
                     .congestionLevelChoices(toEnumValues(CongestionLevelChoice.class))
                     .congestionHistoricalDateChoices(toEnumQueryValues(CongestionHistoricalDateChoice.class))
                     .build();

--- a/src/main/java/bokjak/bokjakserver/domain/category/model/LocationCategory.java
+++ b/src/main/java/bokjak/bokjakserver/domain/category/model/LocationCategory.java
@@ -1,6 +1,7 @@
 package bokjak.bokjakserver.domain.category.model;
 
 import bokjak.bokjakserver.common.constant.ConstraintConstants;
+import bokjak.bokjakserver.common.model.BaseEntity;
 import bokjak.bokjakserver.domain.location.model.Location;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -16,7 +17,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class LocationCategory {
+public class LocationCategory extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/bokjak/bokjakserver/domain/category/model/SpotCategory.java
+++ b/src/main/java/bokjak/bokjakserver/domain/category/model/SpotCategory.java
@@ -1,6 +1,7 @@
 package bokjak.bokjakserver.domain.category.model;
 
 import bokjak.bokjakserver.common.constant.ConstraintConstants;
+import bokjak.bokjakserver.common.model.BaseEntity;
 import bokjak.bokjakserver.domain.spot.model.Spot;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -15,7 +16,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SpotCategory {
+public class SpotCategory extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/bokjak/bokjakserver/domain/category/service/CategoryService.java
+++ b/src/main/java/bokjak/bokjakserver/domain/category/service/CategoryService.java
@@ -2,6 +2,7 @@ package bokjak.bokjakserver.domain.category.service;
 
 import bokjak.bokjakserver.common.dummy.DummyLocationCategory;
 import bokjak.bokjakserver.common.dummy.DummySpotCategory;
+import bokjak.bokjakserver.common.model.BaseEntity;
 import bokjak.bokjakserver.domain.category.dto.CategoryDto.*;
 import bokjak.bokjakserver.domain.category.model.LocationCategory;
 import bokjak.bokjakserver.domain.category.model.SpotCategory;
@@ -11,7 +12,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 @Transactional(readOnly = true)
@@ -20,14 +23,27 @@ public class CategoryService {
     private final LocationCategoryRepository locationCategoryRepository;
     private final SpotCategoryRepository spotCategoryRepository;
 
-    public AllCategoryResponse getAllCategory(){
-        List<LocationCategoryResponse> locationCategoryResponses = locationCategoryRepository.findAll()
+    public AllCategories getAllCategory() {
+        List<LocationCategory> locationCategoryList = locationCategoryRepository.findAll();
+        List<SpotCategory> spotCategoryList = spotCategoryRepository.findAll();
+
+        LocalDateTime lastUpdatedTime = resolveLastUpdatedTime(locationCategoryList, spotCategoryList);
+
+        List<LocationCategoryResponse> locationCategoryResponses = locationCategoryList
                 .stream().map(LocationCategoryResponse::of)
                 .toList();
-        List<SpotCategoryResponse> spotCategoryResponses = spotCategoryRepository.findAll()
+        List<SpotCategoryResponse> spotCategoryResponses = spotCategoryList
                 .stream().map(SpotCategoryResponse::of)
                 .toList();
-        return AllCategoryResponse.of(locationCategoryResponses, spotCategoryResponses);
+        return AllCategories.of(locationCategoryResponses, spotCategoryResponses, lastUpdatedTime);
+    }
+
+    private LocalDateTime resolveLastUpdatedTime(List<LocationCategory> locationCategoryList, List<SpotCategory> spotCategoryList) {
+        List<LocalDateTime> updatedTimeList = new java.util.ArrayList<>();
+        updatedTimeList.addAll(locationCategoryList.stream().map(BaseEntity::getUpdatedAt).toList());
+        updatedTimeList.addAll(spotCategoryList.stream().map(BaseEntity::getUpdatedAt).toList());
+
+        return updatedTimeList.stream().max(LocalDateTime::compareTo).orElseThrow(NoSuchElementException::new);
     }
 
     // Dummy 생성 및 테스트용 메서드

--- a/src/main/java/bokjak/bokjakserver/domain/location/controller/LocationController.java
+++ b/src/main/java/bokjak/bokjakserver/domain/location/controller/LocationController.java
@@ -3,6 +3,7 @@ package bokjak.bokjakserver.domain.location.controller;
 import bokjak.bokjakserver.common.constant.SwaggerConstants;
 import bokjak.bokjakserver.common.dto.ApiResponse;
 import bokjak.bokjakserver.common.dto.PageResponse;
+import bokjak.bokjakserver.common.dto.PageWithLastModified;
 import bokjak.bokjakserver.config.security.PrincipalDetails;
 import bokjak.bokjakserver.domain.congestion.dto.CongestionDto.DailyCongestionStatisticResponse;
 import bokjak.bokjakserver.domain.location.dto.LocationDto.BookmarkResponse;
@@ -18,9 +19,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.ServletWebRequest;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import static bokjak.bokjakserver.common.constant.GlobalConstants.TOP_LOCATIONS_SIZE;
@@ -51,12 +57,23 @@ public class LocationController {
 
     @GetMapping("/simple")
     @Operation(summary = SwaggerConstants.LOCATION_GET_ALL, description = SwaggerConstants.LOCATION_GET_ALL_DESCRIPTION)
-    public ApiResponse<PageResponse<LocationSimpleCardResponse>> getSimpleLocations(
+    public ResponseEntity<ApiResponse<PageResponse<LocationSimpleCardResponse>>> getSimpleLocations(
+            ServletWebRequest request,
             @PageableDefault(sort = "id", direction = Sort.Direction.ASC) Pageable pageable,
             @RequestParam(required = false) Long cursorId
     ) {
-        PageResponse<LocationSimpleCardResponse> pageResponse = locationService.getLocations(pageable, cursorId);
-        return success(pageResponse);
+        PageWithLastModified<LocationSimpleCardResponse> result = locationService.getSimpleLocations(pageable, cursorId);
+        ZonedDateTime lastModifiedAt = ZonedDateTime.of(result.getLastModified(), ZoneId.systemDefault());
+
+        // Header의 If-Modified-Since와 같다면 304 응답
+        if (request.checkNotModified(lastModifiedAt.toInstant().toEpochMilli())) {
+            return null;
+        }
+
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noCache())
+                .lastModified(lastModifiedAt)   // HTTP Cache: Last-Modified
+                .body(ApiResponse.success(result.getPageResponse()));
     }
 
     @GetMapping("/top")

--- a/src/main/java/bokjak/bokjakserver/domain/location/service/LocationService.java
+++ b/src/main/java/bokjak/bokjakserver/domain/location/service/LocationService.java
@@ -13,6 +13,7 @@ import bokjak.bokjakserver.domain.congestion.exception.CongestionException;
 import bokjak.bokjakserver.domain.congestion.model.Congestion;
 import bokjak.bokjakserver.domain.congestion.model.CongestionLevel;
 import bokjak.bokjakserver.domain.congestion.model.DailyCongestionStatistic;
+import bokjak.bokjakserver.domain.congestion.model.WeeklyCongestionStatistic;
 import bokjak.bokjakserver.domain.congestion.repository.CongestionRepository;
 import bokjak.bokjakserver.domain.congestion.repository.DailyCongestionStatisticRepository;
 import bokjak.bokjakserver.domain.location.dto.LocationDto.BookmarkResponse;
@@ -78,11 +79,12 @@ public class LocationService {
         Page<Location> locations = locationRepository.getLocations(pageable, cursorId);
         Page<LocationSimpleCardResponse> responsePage = locations.map(LocationSimpleCardResponse::of);
 
-        return PageWithLastModified.of(responsePage, resolveLastModifiedAt(locations));
+        return PageWithLastModified.of(responsePage, this.extractLocationsLastModifiedAt(locations));
     }
 
     // 혼잡도 낮은순 TOP N 조회 : 주간 통계 기반 정렬
-    public PageResponse<LocationCardResponse> getTopRelaxingLocations(Pageable pageable) {
+    // TODO: Redis 랭킹 테이블로 저장
+    public PageWithLastModified<LocationCardResponse> getTopRelaxingLocations(Pageable pageable) {
         User currentUser = userService.getCurrentUser();
 
         LocalDateTime start = CustomDateUtils.makePastWeekDayDateTime(Calendar.MONDAY, LocalTime.MIN);// 월요일 00시 00
@@ -90,7 +92,11 @@ public class LocationService {
 
         Page<Location> resultPage = locationRepository.getTopOfWeeklyAverageCongestion(pageable, start, end);
 
-        return makeLocationCardPageResponse(currentUser, resultPage);
+        List<LocalDateTime> createdAtList = new ArrayList<>();
+        resultPage.forEach(location -> createdAtList.addAll(location.getWeeklyCongestionStatisticList()
+                .stream().map(WeeklyCongestionStatistic::getCreatedAt).toList()));
+
+        return PageWithLastModified.of(makeLocationCardPage(currentUser, resultPage), resolveLastModifiedAt(createdAtList));
     }
 
     // 내가 북마크한 로케이션 리스트 조회
@@ -160,19 +166,25 @@ public class LocationService {
     }
 
     /* private */
-    private LocalDateTime resolveLastModifiedAt(Page<Location> locationList) {// 가장 마지막에 수정된 시각 추출
+    private LocalDateTime extractLocationsLastModifiedAt(Page<Location> locationList) {// 가장 마지막에 수정된 시각 추출
         List<LocalDateTime> lastModifiedTimeList = locationList.stream().map(BaseEntity::getUpdatedAt).toList();
 
-        return lastModifiedTimeList.stream().max(LocalDateTime::compareTo).orElseThrow(NoSuchElementException::new);
+        return resolveLastModifiedAt(lastModifiedTimeList);
+    }
+
+    private LocalDateTime resolveLastModifiedAt(List<LocalDateTime> localDateTimeList) {// 가장 마지막에 수정된 시각 추출
+        return localDateTimeList.stream().max(LocalDateTime::compareTo).orElseThrow(NoSuchElementException::new);
     }
 
     private PageResponse<LocationCardResponse> makeLocationCardPageResponse(User currentUser, Page<Location> resultPage) {
+        return PageResponse.of(makeLocationCardPage(currentUser, resultPage));
+    }
+
+    private Page<LocationCardResponse> makeLocationCardPage(User currentUser, Page<Location> resultPage) {
         List<Long> bookmarkedLocationIdList = locationBookmarkRepository.findAllByUser(currentUser).stream()
                 .map(it -> it.getLocation().getId()).toList();
-        Page<LocationCardResponse> responsePage = resultPage
-                .map(it -> LocationCardResponse.of(it, bookmarkedLocationIdList.contains(it.getId())));
 
-        return PageResponse.of(responsePage);
+        return resultPage.map(it -> LocationCardResponse.of(it, bookmarkedLocationIdList.contains(it.getId())));
     }
 
     // 혼잡도 예측


### PR DESCRIPTION
## PR 요약
HTTP 캐싱 Last-Modified 적용 #55 

## 구현한 내용 또는 수정한 내용
- 카테고리 전체 조회
- 로케이션 단순 조회
- 로케이션 여유순 TOP 5 조회

Response Header에는 Last-Modified를 넣어 응답하게 되고,
요청할 때 이 값을 Header의 If-Modified-Since에 넣게 되면 304 응답을 하게 되어 네트워크 성능이 개선됩니다.

정확한 성능 개선폭은 AWS 서버에 올려봐야 알 듯 합니다.

## 추가로 알리고 싶은 내용

## 관련 이슈

## 체크리스트

- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  WBS 업데이트해주세요. (제목에 WBS 번호 달아주세요)
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요!
