### PR TITLE
hotfix: 로케이션, 스팟 쿼리 오류 해결

### DIFF
--- a/src/main/java/bokjak/bokjakserver/domain/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/bokjak/bokjakserver/domain/comment/repository/CommentRepositoryImpl.java
@@ -41,7 +41,8 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                                 .from(userBlockUser)
                                 .where(userBlockUser.blockerUser.id.eq(userId))))
                         .and(gtCursorId(cursorId)))
-                .limit(CustomSliceExecutionUtils.buildSliceLimit(pageable.getPageSize()));
+                .limit(CustomSliceExecutionUtils.buildSliceLimit(pageable.getPageSize()))
+                .distinct();
 
         return CustomSliceExecutionUtils.getSlice(query.fetch(), pageable);
     }
@@ -58,7 +59,8 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                                 .from(userBlockUser)
                                 .where(userBlockUser.blockerUser.id.eq(userId))))
                         .and(gtCursorId(cursorId)))
-                .limit(CustomSliceExecutionUtils.buildSliceLimit(pageable.getPageSize()));
+                .limit(CustomSliceExecutionUtils.buildSliceLimit(pageable.getPageSize()))
+                .distinct();
 
         return CustomSliceExecutionUtils.getSlice(query.fetch(), pageable);
     }

--- a/src/main/java/bokjak/bokjakserver/domain/location/repository/LocationRepositoryImpl.java
+++ b/src/main/java/bokjak/bokjakserver/domain/location/repository/LocationRepositoryImpl.java
@@ -108,9 +108,10 @@ public class LocationRepositoryImpl implements LocationRepositoryCustom {
 
     /* JPAQuery */
     public JPAQuery<Location> selectFromSimpleLocationPrefix() {// 로케이션 페이지네이션 조회
-        return queryFactory.selectFrom(location).distinct()
+        return queryFactory.selectFrom(location)
                 .join(location.locationCategory, locationCategory).fetchJoin()
-                .leftJoin(location.locationBookmarkList, locationBookmark);
+                .leftJoin(location.locationBookmarkList, locationBookmark)
+                .distinct();
     }
 
     public JPAQuery<Location> selectFromSimpleLocationWithBookmarkListFetchJoinedPrefix() {// 로케이션 페이지네이션 없이 조회

--- a/src/main/java/bokjak/bokjakserver/domain/location/repository/LocationRepositoryImpl.java
+++ b/src/main/java/bokjak/bokjakserver/domain/location/repository/LocationRepositoryImpl.java
@@ -108,8 +108,8 @@ public class LocationRepositoryImpl implements LocationRepositoryCustom {
 
     /* JPAQuery */
     public JPAQuery<Location> selectFromSimpleLocationPrefix() {// 로케이션 페이지네이션 조회
-        return queryFactory.selectFrom(location)
-                .leftJoin(location.locationCategory, locationCategory).fetchJoin()
+        return queryFactory.selectFrom(location).distinct()
+                .join(location.locationCategory, locationCategory).fetchJoin()
                 .leftJoin(location.locationBookmarkList, locationBookmark);
     }
 

--- a/src/main/java/bokjak/bokjakserver/domain/spot/repository/SpotRepositoryImpl.java
+++ b/src/main/java/bokjak/bokjakserver/domain/spot/repository/SpotRepositoryImpl.java
@@ -146,7 +146,7 @@ public class SpotRepositoryImpl implements SpotRepositoryCustom {
      * JPA Query: Prefix
      **/
     private JPAQuery<Spot> selectFromSpotExceptBlockedAuthorsPrefix(Long userId) {// 일반적인 리스트 조회
-        return queryFactory.selectFrom(spot).distinct()
+        return queryFactory.selectFrom(spot)
                 .join(spot.user, user).fetchJoin()
                 .join(spot.location, location).fetchJoin()
                 .join(spot.spotCategory, spotCategory).fetchJoin()
@@ -155,14 +155,16 @@ public class SpotRepositoryImpl implements SpotRepositoryCustom {
                 .where(spot.user.id.notIn(JPAExpressions.select(userBlockUser.blockedUser.id)  // 차단한 유저 제외
                         .from(userBlockUser)
                         .where(userBlockUser.blockerUser.id.eq(userId))
-                ));
+                ))
+                .distinct();
     }
 
     private JPAQuery<Spot> selectFromSpotIncludingBlockedAuthorsPrefix() { // 차단한 유저를 포함한 조회: 일반 리스트 조회 쿼리문보다 간단
-        return queryFactory.selectFrom(spot).distinct()
+        return queryFactory.selectFrom(spot)
                 .join(spot.user, user).fetchJoin()
                 .leftJoin(spot.spotBookmarkList, spotBookmark)
-                .leftJoin(spot.spotImageList, spotImage);
+                .leftJoin(spot.spotImageList, spotImage)
+                .distinct();
     }
 
     private JPAQuery<Spot> selectFromSpotIncludingBlockedAuthorsWithBookmarkListFetchJoinedPrefix() {

--- a/src/main/java/bokjak/bokjakserver/domain/spot/repository/SpotRepositoryImpl.java
+++ b/src/main/java/bokjak/bokjakserver/domain/spot/repository/SpotRepositoryImpl.java
@@ -146,7 +146,7 @@ public class SpotRepositoryImpl implements SpotRepositoryCustom {
      * JPA Query: Prefix
      **/
     private JPAQuery<Spot> selectFromSpotExceptBlockedAuthorsPrefix(Long userId) {// 일반적인 리스트 조회
-        return queryFactory.selectFrom(spot)
+        return queryFactory.selectFrom(spot).distinct()
                 .join(spot.user, user).fetchJoin()
                 .join(spot.location, location).fetchJoin()
                 .join(spot.spotCategory, spotCategory).fetchJoin()
@@ -159,7 +159,7 @@ public class SpotRepositoryImpl implements SpotRepositoryCustom {
     }
 
     private JPAQuery<Spot> selectFromSpotIncludingBlockedAuthorsPrefix() { // 차단한 유저를 포함한 조회: 일반 리스트 조회 쿼리문보다 간단
-        return queryFactory.selectFrom(spot)
+        return queryFactory.selectFrom(spot).distinct()
                 .join(spot.user, user).fetchJoin()
                 .leftJoin(spot.spotBookmarkList, spotBookmark)
                 .leftJoin(spot.spotImageList, spotImage);


### PR DESCRIPTION
## PR 요약
이전에 일대다 fetch join을 제거하는 과정에서 DISTINCT문을 생략해서 발생한 문제.
fetch join이 아니기 때문에 일대다에 대해서 다 가져오게 되고, 중복되는 레코드들이 발생했음 

## 구현한 내용 또는 수정한 내용

## 추가로 알리고 싶은 내용

## 관련 이슈

## 체크리스트

- [x]  본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x]  WBS 업데이트해주세요. (제목에 WBS 번호 달아주세요)
- [x]  라벨 체크해주세요.
- [x]  .yml 파일 수정 내용이 있다면 공유해주세요!
